### PR TITLE
Updating batman time convention

### DIFF
--- a/AWESim_SOSS/sim2D/awesim.py
+++ b/AWESim_SOSS/sim2D/awesim.py
@@ -585,8 +585,6 @@ class TSO(object):
         if column is None: column = list(range(self.tso.shape[-1]))
         
         n_colors = len(column)
-        # colors = plt.cm.coolwarm(np.linspace(0.1, 0.9, n_colors))
-        # color_cycle = ['#%02x#%02x#%02x' % (int(rgb[0]*255), int(rgb[1]*255), int(rgb[2]*255)) for rgb in colors[:,0:-1]]
         color_cycle = cmap(np.linspace(0, cmap.N, n_colors, dtype=int))
         
         for kcol, col in tqdm(enumerate(column), total=len(column)):

--- a/AWESim_SOSS/sim2D/awesim.py
+++ b/AWESim_SOSS/sim2D/awesim.py
@@ -623,7 +623,7 @@ class TSO(object):
                 tmodel.rp = self.rp[col]
                 theory = tmodel.light_curve(tmodel)
                 theory *= max(lightcurve)/max(theory)
-                print(color_cycle[kcol%n_colors])
+                
                 plt.plot(time, theory, label=label+' model', marker='.', ls='--', color=color_cycle[kcol%n_colors])
             
             data_time = self.time[self.ngrps-1::self.ngrps].copy() 

--- a/AWESim_SOSS/sim2D/awesim.py
+++ b/AWESim_SOSS/sim2D/awesim.py
@@ -557,7 +557,9 @@ class TSO(object):
         plt.ylabel('Count Rate [ADU/s]')
         plt.grid()
         
-    def plot_lightcurve(self, column=None, time_unit='seconds', cmap=plt.cm.coolwarm, resolution_mult=20):
+    def plot_lightcurve(self, column=None, time_unit='seconds', 
+                        cmap=plt.cm.coolwarm, resolution_mult=20, 
+                        theory_alpha=0.9):
         """
         Plot a lightcurve for each column index given
         
@@ -624,7 +626,7 @@ class TSO(object):
                 theory = tmodel.light_curve(tmodel)
                 theory *= max(lightcurve)/max(theory)
                 
-                plt.plot(time, theory, label=label+' model', marker='.', ls='--', color=color_cycle[kcol%n_colors])
+                plt.plot(time, theory, label=label+' model', marker='.', ls='--', color=color_cycle[kcol%n_colors], alpha=theory_alpha)
             
             data_time = self.time[self.ngrps-1::self.ngrps].copy() 
             

--- a/AWESim_SOSS/sim2D/awesim.py
+++ b/AWESim_SOSS/sim2D/awesim.py
@@ -13,6 +13,7 @@ import astropy.constants as ac
 from astropy.io import fits
 
 from multiprocessing.dummy import Pool as ThreadPool
+from multiprocessing import cpu_count
 import time
 import warnings
 import datetime

--- a/AWESim_SOSS/sim2D/awesim.py
+++ b/AWESim_SOSS/sim2D/awesim.py
@@ -126,7 +126,7 @@ class TSO(object):
         self.tso_order1_ideal = np.zeros(self.dims)
         self.tso_order2_ideal = np.zeros(self.dims)
     
-    def run_simulation(self, planet=None, tmodel=None, ld_coeffs=None,
+    def run_simulation(self, planet=None, tmodel=None, time_unit='days',ld_coeffs=None,
                        ld_profile='quadratic', model_grid=None, verbose=True):
         """
         Generate the simulated 2D data given the initialized TSO object
@@ -139,6 +139,9 @@ class TSO(object):
             The wavelength and Rp/R* of the planet at t=0 
         tmodel: batman.transitmodel.TransitModel (optional)
             The transit model of the planet
+        time_unit: string
+            The string indicator for the units that the tmodel.t array is in
+            options: 'seconds', 'minutes', 'hours', 'days' (default)
         ld_coeffs: array-like (optional)
             A 3D array that assigns limb darkening coefficients to each pixel, i.e. wavelength
         ld_profile: str (optional)
@@ -201,9 +204,15 @@ class TSO(object):
             # Set time of inferior conjunction
             if self.tmodel.t0 is None or self.time[0] > self.tmodel.t0 > self.time[-1]:
                 self.tmodel.t0 = self.time[self.nframes//2]
-                
+            
             # Convert days to seconds
-            self.tmodel.t *= 86400
+            days_to_seconds = 86400.
+            if time_unit == 'seconds':
+                self.tmodel.t *= days_to_seconds
+            if time_unit == 'minutes':
+                self.tmodel.t *= days_to_seconds / 60
+            if time_unit == 'hours':
+                self.tmodel.t *= days_to_seconds / 3600
             
             # Set the ld_coeffs if provided
             stellar_params = [getattr(tmodel, p) for p in plist]

--- a/AWESim_SOSS/sim2D/awesim.py
+++ b/AWESim_SOSS/sim2D/awesim.py
@@ -559,7 +559,7 @@ class TSO(object):
         
     def plot_lightcurve(self, column=None, time_unit='seconds', 
                         cmap=plt.cm.coolwarm, resolution_mult=20, 
-                        theory_alpha=0.9):
+                        theory_alpha=0.1):
         """
         Plot a lightcurve for each column index given
         

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Now the code to generate a simulated planetary transit around our star might loo
 
 ```python
 tso.run_simulation(planet=planet1D, tmodel=tmodel, time_unit='seconds')
-tso.plot_lightcurve(col=42)
+tso.plot_lightcurve(column=42)
 ```
 
 We can write this to a FITS file directly ingestible by the JWST pipeline with:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ params.ecc = 0.                               # eccentricity
 params.w = 90.                                # longitude of periastron (in degrees)
 params.limb_dark = 'quadratic'                # limb darkening profile to use
 params.u = [0.1,0.1]                          # limb darkening coefficients
-tmodel = batman.TransitModel(params, tso.time, time_unit='seconds')
+tmodel = batman.TransitModel(params, tso.time)
 tmodel.teff = 3500                            # effective temperature of the host star
 tmodel.logg = 5                               # log surface gravity of the host star
 tmodel.feh = 0                                # metallicity of the host star
@@ -85,7 +85,7 @@ tmodel.feh = 0                                # metallicity of the host star
 Now the code to generate a simulated planetary transit around our star might look like:
 
 ```python
-tso.run_simulation(planet=planet1D, tmodel=tmodel)
+tso.run_simulation(planet=planet1D, tmodel=tmodel, time_unit='seconds')
 ```
 
 We can write this to a FITS file directly ingestible by the JWST pipeline with:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ params.ecc = 0.                               # eccentricity
 params.w = 90.                                # longitude of periastron (in degrees)
 params.limb_dark = 'quadratic'                # limb darkening profile to use
 params.u = [0.1,0.1]                          # limb darkening coefficients
-tmodel = batman.TransitModel(params, tso.time)
+tmodel = batman.TransitModel(params, tso.time, time_unit='seconds')
 tmodel.teff = 3500                            # effective temperature of the host star
 tmodel.logg = 5                               # log surface gravity of the host star
 tmodel.feh = 0                                # metallicity of the host star

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Now the code to generate a simulated planetary transit around our star might loo
 
 ```python
 tso.run_simulation(planet=planet1D, tmodel=tmodel, time_unit='seconds')
+tso.plot_lightcurve()
 ```
 
 We can write this to a FITS file directly ingestible by the JWST pipeline with:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ params = batman.TransitParams()
 params.t0 = 0.                                # time of inferior conjunction
 params.per = 5.7214742                        # orbital period (days)
 params.a = 0.0558*q.AU.to(ac.R_sun)*0.66      # semi-major axis (in units of stellar radii)
+params.rp = 0.1                               # radius ratio for Jupiter orbiting the Sun
 params.inc = 89.8                             # orbital inclination (in degrees)
 params.ecc = 0.                               # eccentricity
 params.w = 90.                                # longitude of periastron (in degrees)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Now the code to generate a simulated planetary transit around our star might loo
 
 ```python
 tso.run_simulation(planet=planet1D, tmodel=tmodel, time_unit='seconds')
-tso.plot_lightcurve()
+tso.plot_lightcurve(col=42)
 ```
 
 We can write this to a FITS file directly ingestible by the JWST pipeline with:

--- a/awesim_soss_test_planet_spec.py
+++ b/awesim_soss_test_planet_spec.py
@@ -32,4 +32,4 @@ tmodel.logg = 5                               # log surface gravity of the host 
 tmodel.feh = 0                                # metallicity of the host star
 
 tso.run_simulation(planet=planet1D, tmodel=tmodel, time_unit='seconds')
-tso.plot_lightcurve(col=42)
+tso.plot_lightcurve(column=42)

--- a/awesim_soss_test_planet_spec.py
+++ b/awesim_soss_test_planet_spec.py
@@ -1,0 +1,35 @@
+import matplotlib
+matplotlib.use('Qt5Agg')
+
+import numpy as np
+from AWESim_SOSS.sim2D import awesim
+import astropy.units as q
+import astropy.constants as ac
+import batman
+from pkg_resources import resource_filename
+star = np.genfromtxt(resource_filename('AWESim_SOSS','files/scaled_spectrum.txt'), unpack=True)
+star1D = [star[0]*q.um, (star[1]*q.W/q.m**2/q.um).to(q.erg/q.s/q.cm**2/q.AA)]
+
+
+tso = awesim.TSO(ngrps=3, nints=5, star=star1D)
+
+planet_file = resource_filename('AWESim_SOSS', '/files/WASP107b_pandexo_input_spectrum.dat')
+planet1D = np.genfromtxt(planet_file, unpack=True)
+
+params = batman.TransitParams()
+params.t0 = 0.                                # time of inferior conjunction
+params.per = 5.7214742                        # orbital period (days)
+params.a = 0.0558*q.AU.to(ac.R_sun)*0.66      # semi-major axis (in units of stellar radii)
+params.rp = 0.1                               # radius ratio for Jupiter orbiting the Sun
+params.inc = 89.8                             # orbital inclination (in degrees)
+params.ecc = 0.                               # eccentricity
+params.w = 90.                                # longitude of periastron (in degrees)
+params.limb_dark = 'quadratic'                # limb darkening profile to use
+params.u = [0.1,0.1]                          # limb darkening coefficients
+tmodel = batman.TransitModel(params, tso.time)
+tmodel.teff = 3500                            # effective temperature of the host star
+tmodel.logg = 5                               # log surface gravity of the host star
+tmodel.feh = 0                                # metallicity of the host star
+
+tso.run_simulation(planet=planet1D, tmodel=tmodel, time_unit='seconds')
+tso.plot_lightcurve(col=42)

--- a/awesim_soss_test_planet_spec.py
+++ b/awesim_soss_test_planet_spec.py
@@ -1,7 +1,7 @@
 import matplotlib
 matplotlib.use('Qt5Agg')
 
-plt = matplotlib.pyplot
+import matplotlib.pyplot as plt
 
 import numpy as np
 from AWESim_SOSS.sim2D import awesim

--- a/awesim_soss_test_planet_spec.py
+++ b/awesim_soss_test_planet_spec.py
@@ -3,7 +3,7 @@ matplotlib.use('Qt5Agg')
 
 import matplotlib.pyplot as plt
 
-from pylab import *;ion()
+# from pylab import *;ion()
 
 import numpy as np
 from AWESim_SOSS.sim2D import awesim
@@ -45,4 +45,4 @@ tmodel.feh = 0                                # metallicity of the host star
 tso.run_simulation(planet=planet1D, tmodel=tmodel)
 tso.plot_lightcurve(column=range(10,2048,500))
 
-# plt.show()
+plt.show()

--- a/awesim_soss_test_planet_spec.py
+++ b/awesim_soss_test_planet_spec.py
@@ -3,6 +3,8 @@ matplotlib.use('Qt5Agg')
 
 import matplotlib.pyplot as plt
 
+from pylab import *;ion()
+
 import numpy as np
 from AWESim_SOSS.sim2D import awesim
 import astropy.units as q
@@ -21,22 +23,26 @@ tso = awesim.TSO(ngrps=3, nints=5, star=star1D)
 planet_file = resource_filename('AWESim_SOSS', '/files/WASP107b_pandexo_input_spectrum.dat')
 planet1D = np.genfromtxt(planet_file, unpack=True)
 
+# From https://www.cfa.harvard.edu/~lkreidberg/batman/quickstart.html
 params = batman.TransitParams()
-params.t0 = 0.                                # time of inferior conjunction
-params.per = 5.7214742                        # orbital period (days)
-params.a = 0.0558*q.AU.to(ac.R_sun)*0.66      # semi-major axis (in units of stellar radii)
-params.rp = 0.1                               # radius ratio for Jupiter orbiting the Sun
-params.inc = 89.8                             # orbital inclination (in degrees)
-params.ecc = 0.                               # eccentricity
-params.w = 90.                                # longitude of periastron (in degrees)
-params.limb_dark = 'quadratic'                # limb darkening profile to use
+params.t0 = 0.                       #time of inferior conjunction
+params.per = 1.                      #orbital period
+params.rp = 0.1                      #planet radius (in units of stellar radii)
+params.a = 15.                       #semi-major axis (in units of stellar radii)
+params.inc = 87.                     #orbital inclination (in degrees)
+params.ecc = 0.                      #eccentricity
+params.w = 90.                       #longitude of periastron (in degrees)
+
+# Added here
+params.u = [0.1, 0.3]                #limb darkening coefficients [u1, u2]
+params.limb_dark = "quadratic"       #limb darkening model
 params.u = [0.1,0.1]                          # limb darkening coefficients
 tmodel = batman.TransitModel(params, tso.time/day2sec)
 tmodel.teff = 3500                            # effective temperature of the host star
 tmodel.logg = 5                               # log surface gravity of the host star
 tmodel.feh = 0                                # metallicity of the host star
 
-tso.run_simulation(planet=planet1D, tmodel=tmodel, time_unit='seconds')
-tso.plot_lightcurve(column=42)
+tso.run_simulation(planet=planet1D, tmodel=tmodel)
+tso.plot_lightcurve(column=range(10,2048,500))
 
-plt.show()
+# plt.show()


### PR DESCRIPTION
The batman time configuration was previously converting seconds to MEGA seconds (self.time*86400)  instead of converting seconds to days (as expected).

added `time_unit` to the self.run_simulation call to match the time units in `tmodel.t`to the self.time configuration.

added `time_unit` to the self.plot_lightcurve call to match the time units in `self.time` to the theory lightcurve model configuration.

The `time_unit` kwarg in each call is addressed a *different* time array that needed to be manipulated.

For next time: use `astropy.units.seconds` for the `self.time` configuration; then use `astropy.units.jdays`for the `tmodel.t` configuraiton; and finally, use `astropy.units.convert` to switch between them in the plotting and `run` methods.
